### PR TITLE
minor typos

### DIFF
--- a/collection/gcp/assets/cloud-config.yaml
+++ b/collection/gcp/assets/cloud-config.yaml
@@ -58,7 +58,7 @@ write_files:
     Environment="HOME=/home/composer"
     ExecStartPre=sh /home/composer/init.sh
     ExecStart=/usr/bin/docker run --rm -v  /var/run/docker.sock:/var/run/docker.sock -v "/home/composer/.docker:/root/.docker" -v "/home/composer:/home/composer" -w="/home/composer/opencspm/docker" docker/compose:1.27.4 up
-    ExecStop=/usr/bin/docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "/home/composer/.docker:/root/.docker" -v "/home/composer:/home/composer" -w="/home/composer/opencspom/docker" docker/compose:1.27.4 rm -f
+    ExecStop=/usr/bin/docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "/home/composer/.docker:/root/.docker" -v "/home/composer:/home/composer" -w="/home/composer/opencspm/docker" docker/compose:1.27.4 down
     Restart=on-failure
     RestartSec=10
     [Install]

--- a/collection/gcp/versions.tf
+++ b/collection/gcp/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">=0.12.6"
+  required_version = ">=0.13.0"
 }


### PR DESCRIPTION
Some minor typos in the code:
a) The minimum terraform version needs to be 0.13.0 and above. Reason "Module support for depends_on was added in Terraform 0.13, and previous versions can only use it with resources." Else, lines like these fail - https://github.com/OpenCSPM/opencspm-terraform-gcp/blob/main/collection/gcp/storage.tf#L77
b)Typo here https://github.com/OpenCSPM/opencspm-terraform-gcp/blob/main/collection/gcp/assets/cloud-config.yaml#L61
c) https://github.com/OpenCSPM/opencspm-terraform-gcp/blob/main/collection/gcp/assets/cloud-config.yaml#L61 "rm -f" does not work as expected.